### PR TITLE
Add 4 fragment's UI

### DIFF
--- a/app/src/main/java/h2mud2/ganpanproject/gandan/activity/MainActivity.kt
+++ b/app/src/main/java/h2mud2/ganpanproject/gandan/activity/MainActivity.kt
@@ -2,6 +2,7 @@ package h2mud2.ganpanproject.gandan.activity
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter

--- a/app/src/main/java/h2mud2/ganpanproject/gandan/fragment/search_fragment.kt
+++ b/app/src/main/java/h2mud2/ganpanproject/gandan/fragment/search_fragment.kt
@@ -6,11 +6,22 @@ import android.os.Handler
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.SearchView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import h2mud2.ganpanproject.gandan.R
+import h2mud2.ganpanproject.gandan.adapter.Banner
 
 class search_fragment: Fragment() {
+
+    lateinit var banner_btn : Button
+    lateinit var steelBanner_btn: Button
+    lateinit var hanging_btn : Button
+    lateinit var designItem_btn: Button
+    lateinit var search_item: SearchView
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -18,6 +29,28 @@ class search_fragment: Fragment() {
     ): View? {
 
         val view = inflater.inflate(R.layout.search_fragment, container, false)
+
+        banner_btn = view.findViewById<Button>(R.id.banner)
+        steelBanner_btn = view.findViewById<Button>(R.id.steelbanner)
+        hanging_btn = view.findViewById<Button>(R.id.hanging)
+        designItem_btn = view.findViewById<Button>(R.id.designItem)
+
+        banner_btn.setOnClickListener{
+            Toast.makeText(view.context, "배너가 클릭되었습니다.", Toast.LENGTH_SHORT).show();
+        }
+
+        steelBanner_btn.setOnClickListener{
+            Toast.makeText(view.context, "스틸배너가 클릭되었습니다.", Toast.LENGTH_SHORT).show();
+        }
+
+        hanging_btn.setOnClickListener{
+            Toast.makeText(view.context, "현수막이 클릭되었습니다.", Toast.LENGTH_SHORT).show();
+        }
+
+        designItem_btn.setOnClickListener{
+            Toast.makeText(view.context, "디자인상품이 클릭되었습니다.", Toast.LENGTH_SHORT).show();
+        }
+
 
         return view
     }

--- a/app/src/main/res/drawable/btn_rounded.xml
+++ b/app/src/main/res/drawable/btn_rounded.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#4E8AD3"/>
+    <corners android:radius="1000dp"/>
+</shape>

--- a/app/src/main/res/drawable/ic_baseline_search_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_search_24.xml
@@ -1,10 +1,5 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+<vector android:height="24dp" android:tint="#4E8AD3"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
 </vector>

--- a/app/src/main/res/drawable/search_rounded.xml
+++ b/app/src/main/res/drawable/search_rounded.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FFFF"/>
+    <corners android:radius="50dp"/>
+</shape>

--- a/app/src/main/res/drawable/stroke_btn.xml
+++ b/app/src/main/res/drawable/stroke_btn.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:width="1dp" android:color="#5F5F5F"></stroke>
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,9 +8,12 @@
     android:background="#FFFFFF">
 
     <androidx.viewpager.widget.ViewPager
+        android:id="@+id/appViewPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/appViewPager"/>
+        android:layout_marginBottom="56dp"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNavigationMenu"
+        tools:layout_editor_absoluteX="-32dp" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigationMenu"

--- a/app/src/main/res/layout/cart_fragment.xml
+++ b/app/src/main/res/layout/cart_fragment.xml
@@ -6,14 +6,30 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:textColor="#000000"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="장바구니"
+
+    <ImageView
+        android:id="@+id/imageView2"
+        android:layout_width="169dp"
+        android:layout_height="93dp"
+        android:background="@drawable/gandanlogo"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.476" />
+
+    <TextView
+        android:textStyle="bold"
+        android:id="@+id/cart_status_tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="장바구니에 담긴 상품이 없습니다."
+        android:textColor="#909090"
+        android:textSize="15dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/imageView2" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -8,11 +8,22 @@
     android:layout_height="match_parent">
 
 
+    <com.synnapps.carouselview.CarouselView
+        android:id="@+id/item_carousel"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        app:fillColor="#4E8AD3"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar2"
+        app:pageColor="#FFFFFF"
+        app:radius="6dp"
+        app:slideInterval="3000"
+        tools:layout_editor_absoluteX="16dp" />
+
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar2"
         android:layout_width="match_parent"
         android:layout_height="56dp"
-        android:background="@drawable/toolbar"
+        android:background="#AEFFFFFF"
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
@@ -28,18 +39,65 @@
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.appcompat.widget.Toolbar>
 
-    <com.synnapps.carouselview.CarouselView
-        android:id="@+id/item_carousel"
+
+
+    <LinearLayout
+        android:id="@+id/linearLayout2"
         android:layout_width="match_parent"
-        android:layout_height="200dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
-        app:fillColor="#FFFFFF"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar2"
-        app:pageColor="#000000"
-        app:radius="6dp"
-        app:slideInterval="3000"
-        app:strokeColor="#FF777777"
-        tools:layout_editor_absoluteX="0dp" />
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/item_carousel">
+
+        <Button
+            android:id="@+id/bannerButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:drawableLeft="@drawable/banner"
+            android:text="배너"
+            android:textSize="15dp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/steelBannerButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:drawableLeft="@drawable/steelbanner"
+            android:text="스틸배너"
+            android:textSize="15dp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2">
+
+        <Button
+            android:id="@+id/hangingButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:drawableLeft="@drawable/hangingbanner"
+            android:text="현수막"
+            android:textSize="15dp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/designItemButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:drawableLeft="@drawable/design"
+            android:text="디자인상"
+            android:textSize="15dp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/search_fragment.xml
+++ b/app/src/main/res/layout/search_fragment.xml
@@ -2,18 +2,109 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:background="#FFFFFF"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:layout_width="wrap_content"
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/search_item"
+        app:defaultQueryHint="검색어를 입력해주세요."
+        android:backgroundTintMode="screen"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="검색"
-        android:textColor="#000000"
+        app:searchIcon="@drawable/ic_baseline_search_24"
+
+        app:iconifiedByDefault="false"
+        app:layout_constraintTop_toTopOf="parent">
+    </androidx.appcompat.widget.SearchView>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:background="#FAFAFA"
+        android:layout_height="100dp"
+        android:layout_marginBottom="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            android:id="@+id/textView2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="12dp"
+            android:text="추천 검색어"
+            android:textColor="#000000"
+            android:textSize="20dp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <HorizontalScrollView
+
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView2">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/banner"
+                    android:layout_marginLeft="12dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/btn_rounded"
+                    android:text="배너"
+                    android:textColor="#FFFFFF"
+                    android:textSize="15dp"
+                    android:textStyle="bold" />
+
+                <Button
+                    android:id="@+id/steelbanner"
+                    android:layout_marginLeft="12dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/btn_rounded"
+                    android:text="스틸배너"
+                    android:textColor="#FFFFFF"
+                    android:textSize="15dp"
+                    android:textStyle="bold" />
+
+                <Button
+                    android:id="@+id/hanging"
+                    android:layout_marginLeft="12dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/btn_rounded"
+                    android:text="현수막"
+                    android:textColor="#FFFFFF"
+                    android:textSize="15dp"
+                    android:textStyle="bold" />
+
+                <Button
+                    android:id="@+id/designItem"
+                    android:layout_marginLeft="12dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/btn_rounded"
+                    android:text="디자인 상품"
+                    android:textColor="#FFFFFF"
+                    android:textSize="15dp"
+                    android:textStyle="bold" />
+
+            </LinearLayout>
+
+        </HorizontalScrollView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,10 +5,15 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:textViewStyle">@style/customTextViewFontStyle</item>
+        <item name="android:searchViewStyle">@style/customSearchViewStyle</item>
         <item name="android:buttonStyle">@style/customButtonFontStyle</item>
         <item name="android:editTextStyle">@style/customEditTextFontStyle</item>
         <item name="android:radioButtonStyle">@style/customRadioButtonFontStyle</item>
         <item name="android:checkboxStyle">@style/customCheckboxFontStyle</item>
+    </style>
+
+    <style name="customSearchViewStyle" parent="Widget.AppCompat.SearchView">
+        <item name="android:fontFamily">@font/font</item>
     </style>
 
     <style name="customTextViewFontStyle" parent="@android:style/Widget.DeviceDefault.TextView">


### PR DESCRIPTION
## Intro
앱 실행했을 때 뜨는 화면 => SplashActivity
![Screenshot_1603745670](https://user-images.githubusercontent.com/28584299/97227778-512bb500-1819-11eb-854c-24119a1465a9.png)

## Home
앱의 홈 화면 => home_fragment
![Screenshot_1603745675](https://user-images.githubusercontent.com/28584299/97227808-5a1c8680-1819-11eb-8f3a-5a45a8eb1d4e.png)

## Search
상품을 검색하는 화면 => search_fragment
![Screenshot_1603745607](https://user-images.githubusercontent.com/28584299/97227822-60126780-1819-11eb-9486-f60724c93e99.png)

## Menu
카테고리 별로 상품 이동 가능한 화면 => menu_fragment
![Screenshot_1603745602](https://user-images.githubusercontent.com/28584299/97227839-64d71b80-1819-11eb-998e-a8788e75df69.png)

## Account
사용자 계정 관리하는 화면 => account_fragment
![Screenshot_1603745678](https://user-images.githubusercontent.com/28584299/97227862-6accfc80-1819-11eb-80ad-a108703508c4.png)

## Cart
장바구니 화면 => cart_fragment
![Screenshot_1603745680](https://user-images.githubusercontent.com/28584299/97227876-70c2dd80-1819-11eb-8145-a3ba81cb7b81.png)
